### PR TITLE
APIへの通信部を実装

### DIFF
--- a/DataStore/DataStore/NovelListAPIDataStore.swift
+++ b/DataStore/DataStore/NovelListAPIDataStore.swift
@@ -1,0 +1,34 @@
+//
+//  NovelListAPIDataStore.swift
+//  DataStore
+//
+//  Created by ichikawa on 2020/09/03.
+//
+
+import APIKit
+import RxSwift
+
+enum NovelListAPIDataStoreProvider {
+    
+    static func provide() -> NovelListAPIDataStore {
+        return NovelListAPIDataStoreImpl()
+    }
+}
+
+protocol NovelListAPIDataStore {
+    func get() -> Single<NovelListResponse>
+}
+
+private struct NovelListAPIDataStoreImpl: NovelListAPIDataStore {
+    
+    private let session: Session
+
+    init(session: Session = .shared) {
+        self.session = session
+    }
+    
+    func get() -> Single<NovelListResponse> {
+        return .just(NovelListResponseImpl())
+//        return self.session
+    }
+}

--- a/DataStore/DataStore/NovelListAPIDataStore.swift
+++ b/DataStore/DataStore/NovelListAPIDataStore.swift
@@ -28,7 +28,6 @@ private struct NovelListAPIDataStoreImpl: NovelListAPIDataStore {
     }
     
     func get() -> Single<QiitaItemListResponse> {
-//        return .just(NovelListResponseImpl())
         return self.session.rx.response(for: QiitaItemsListRequest())
     }
 }

--- a/DataStore/DataStore/NovelListAPIDataStore.swift
+++ b/DataStore/DataStore/NovelListAPIDataStore.swift
@@ -16,7 +16,7 @@ enum NovelListAPIDataStoreProvider {
 }
 
 protocol NovelListAPIDataStore {
-    func get() -> Single<NovelListResponse>
+    func get() -> Single<QiitaItemListResponse>
 }
 
 private struct NovelListAPIDataStoreImpl: NovelListAPIDataStore {
@@ -27,8 +27,8 @@ private struct NovelListAPIDataStoreImpl: NovelListAPIDataStore {
         self.session = session
     }
     
-    func get() -> Single<NovelListResponse> {
-        return .just(NovelListResponseImpl())
-//        return self.session
+    func get() -> Single<QiitaItemListResponse> {
+//        return .just(NovelListResponseImpl())
+        return self.session.rx.response(for: QiitaItemsListRequest())
     }
 }

--- a/DataStore/DataStore/Utility/APIKit+Rx.swift
+++ b/DataStore/DataStore/Utility/APIKit+Rx.swift
@@ -1,0 +1,31 @@
+//
+//  APIKit+Rx.swift
+//  DataStore
+//
+//  Created by ichikawa on 2020/09/05.
+//
+
+import APIKit
+import RxSwift
+
+extension Session: ReactiveCompatible {}
+
+extension Reactive where Base: Session {
+    
+    func response<T: Request>(for request: T) -> Single<T.Response> {
+
+        return Single.create { [weak base] single -> Disposable in
+            let task = base?.send(request) { result in
+                switch result {
+                case .success(let response):
+                    single(.success(response))
+                case .failure(let error):
+                    single(.error(error))
+                }
+            }
+            return Disposables.create {
+                task?.cancel()
+            }
+        }
+    }
+}

--- a/DataStore/Entity/API/Request/Base/APIRequestable.swift
+++ b/DataStore/Entity/API/Request/Base/APIRequestable.swift
@@ -14,7 +14,7 @@ extension APIRequestable {
     
     var baseURL: URL {
         // qiita
-        return URL(string: "/api/v2/items")!
+        return URL(string: "https://qiita.com/api/v2")!
     }
     
     // TODO もっかい調べる
@@ -26,6 +26,13 @@ extension APIRequestable {
     var dataParser: DataParser {
         return DecodableDataParser()
     }
+
+    var headerFields: [String : String] {
+//        return ["Authorization":"Bearer "]
+        // 一応アクセストークンはgitにプッシュしない
+        return [:]
+    }
+    
 }
 
 extension APIKit.Request where Self.Response: Decodable {

--- a/DataStore/Entity/API/Request/Base/APIRequestable.swift
+++ b/DataStore/Entity/API/Request/Base/APIRequestable.swift
@@ -1,0 +1,11 @@
+//
+//  APIRequestable.swift.swift
+//  DataStore
+//
+//  Created by ichikawa on 2020/09/05.
+//
+
+import Foundation
+import APIKit
+
+protocol APIRequestable: Request {}

--- a/DataStore/Entity/API/Request/Base/APIRequestable.swift
+++ b/DataStore/Entity/API/Request/Base/APIRequestable.swift
@@ -17,22 +17,13 @@ extension APIRequestable {
         return URL(string: "https://qiita.com/api/v2")!
     }
     
-    // TODO もっかい調べる
     var parameters: Any? {
         return JSONEncoder().encodeToDictionary(self)
     }
 
-    // TODO もっかい調べる
     var dataParser: DataParser {
         return DecodableDataParser()
     }
-
-    var headerFields: [String : String] {
-//        return ["Authorization":"Bearer "]
-        // 一応アクセストークンはgitにプッシュしない
-        return [:]
-    }
-    
 }
 
 extension APIKit.Request where Self.Response: Decodable {

--- a/DataStore/Entity/API/Request/Base/APIRequestable.swift
+++ b/DataStore/Entity/API/Request/Base/APIRequestable.swift
@@ -8,4 +8,60 @@
 import Foundation
 import APIKit
 
-protocol APIRequestable: Request {}
+protocol APIRequestable: Request, Encodable {}
+
+extension APIRequestable {
+    
+    var baseURL: URL {
+        // qiita
+        return URL(string: "/api/v2/items")!
+    }
+    
+    // TODO もっかい調べる
+    var parameters: Any? {
+        return JSONEncoder().encodeToDictionary(self)
+    }
+
+    // TODO もっかい調べる
+    var dataParser: DataParser {
+        return DecodableDataParser()
+    }
+}
+
+extension APIKit.Request where Self.Response: Decodable {
+    
+    // 成功した場合
+    func response(from object: Any, urlResponse: HTTPURLResponse) throws -> Response {
+        guard let data = object as? Data else {
+            assertionFailure()
+            throw ResponseError.unexpectedObject(object)
+        }
+        return try JSONDecoder().decode(Response.self, from: data)
+    }
+}
+
+extension JSONEncoder {
+    
+    /// Encodable構造体からDataに変換したのちに、Dictionaryにする(APIのパラメータ生成用)
+    func encodeToDictionary<T: Encodable>(_ value: T) -> [String: Any] {
+        do {
+            let data = try self.encode(value)
+            let jsonObject = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
+            return (jsonObject as? [String: Any]) ?? [:]
+        } catch {
+            print(error.localizedDescription)
+            return [:]
+        }
+    }
+}
+
+final class DecodableDataParser: DataParser {
+
+    var contentType: String? {
+        return "application/json"
+    }
+    
+    func parse(data: Data) throws -> Any {
+        return data
+    }
+}

--- a/DataStore/Entity/API/Request/Type/NovelListAPIRequest.swift
+++ b/DataStore/Entity/API/Request/Type/NovelListAPIRequest.swift
@@ -1,0 +1,9 @@
+//
+//  NovelListAPIRequest.swift
+//  DataStore
+//
+//  Created by ichikawa on 2020/09/05.
+//
+
+import Foundation
+

--- a/DataStore/Entity/API/Request/Type/NovelListAPIRequest.swift
+++ b/DataStore/Entity/API/Request/Type/NovelListAPIRequest.swift
@@ -1,9 +1,0 @@
-//
-//  NovelListAPIRequest.swift
-//  DataStore
-//
-//  Created by ichikawa on 2020/09/05.
-//
-
-import Foundation
-

--- a/DataStore/Entity/API/Request/Type/QiitaItemsListRequest.swift
+++ b/DataStore/Entity/API/Request/Type/QiitaItemsListRequest.swift
@@ -1,0 +1,27 @@
+//
+//  QiitaItemsListRequest.swift
+//  DataStore
+//
+//  Created by ichikawa on 2020/09/08.
+//
+
+import APIKit
+
+struct QiitaItemsListRequest: APIRequestable {
+
+    typealias Response = QiitaItemListResponse
+    
+    var method: HTTPMethod {
+        return .get
+    }
+    
+    var path: String {
+        return "/items"
+    }
+    
+    let page: Int = 1
+    
+    let perPage: Int = 20
+    
+    let query: String = "tag:Swift"
+}

--- a/DataStore/Entity/API/Response/View/QiitaItemListResponse.swift
+++ b/DataStore/Entity/API/Response/View/QiitaItemListResponse.swift
@@ -9,12 +9,12 @@ import Foundation
 
 public struct QiitaItemListResponse: Decodable {
 
-    let items: [Item]
+    public let items: [Item]
 
-    struct Item: Decodable {
-        let title: String
-        let likesCount: Int
-        let user: User
+    public struct Item: Decodable {
+        public let title: String
+        public let likesCount: Int
+        public let user: User
         
         private enum CodingKeys: String, CodingKey {
             case title
@@ -22,8 +22,8 @@ public struct QiitaItemListResponse: Decodable {
             case user
         }
         
-        struct User: Decodable {
-            let id: String
+        public struct User: Decodable {
+            public let id: String
         }
     }
 }

--- a/DataStore/Entity/API/Response/View/QiitaItemListResponse.swift
+++ b/DataStore/Entity/API/Response/View/QiitaItemListResponse.swift
@@ -1,0 +1,43 @@
+//
+//  QiitaItemListResponse.swift
+//  DataStore
+//
+//  Created by ichikawa on 2020/09/08.
+//
+
+import Foundation
+
+public struct QiitaItemListResponse: Decodable {
+
+    let items: [Item]
+
+    struct Item: Decodable {
+        let title: String
+        let likesCount: Int
+        let user: User
+        
+        private enum CodingKeys: String, CodingKey {
+            case title
+            case likesCount = "likes_count"
+            case user
+        }
+        
+        struct User: Decodable {
+            let id: String
+        }
+    }
+}
+
+extension QiitaItemListResponse {
+
+    // ルートが配列のレスポンスをデコードする
+    public init(from decoder: Decoder) throws {
+        var items: [Item] = []
+        var unkeyedContainer = try decoder.unkeyedContainer()
+        while !unkeyedContainer.isAtEnd {
+            let user = try unkeyedContainer.decode(Item.self)
+            items.append(user)
+        }
+        self.init(items: items)
+    }
+}

--- a/DataStore/Repository/NovelListRepository.swift
+++ b/DataStore/Repository/NovelListRepository.swift
@@ -16,7 +16,7 @@ public enum NovelListRepositoryProvider {
 }
 
 public protocol NovelListRepository {
-    func get() -> Single<NovelListResponse>
+    func get() -> Single<QiitaItemListResponse>
 }
 
 private struct NovelListRepositoryImpl: NovelListRepository {
@@ -27,12 +27,7 @@ private struct NovelListRepositoryImpl: NovelListRepository {
         self.api = api
     }
     
-    func get() -> Single<NovelListResponse> {
+    func get() -> Single<QiitaItemListResponse> {
         return api.get()
     }
 }
-
-public protocol NovelListResponse{}
-
-struct NovelListResponseImpl: NovelListResponse {}
-

--- a/DataStore/Repository/NovelListRepository.swift
+++ b/DataStore/Repository/NovelListRepository.swift
@@ -1,0 +1,38 @@
+//
+//  NovelListRepository.swift
+//  DataStore
+//
+//  Created by ichikawa on 2020/09/03.
+//
+
+import Foundation
+import RxSwift
+
+public enum NovelListRepositoryProvider {
+    
+    public static func provide() -> NovelListRepository {
+        return NovelListRepositoryImpl(api: NovelListAPIDataStoreProvider.provide())
+    }
+}
+
+public protocol NovelListRepository {
+    func get() -> Single<NovelListResponse>
+}
+
+private struct NovelListRepositoryImpl: NovelListRepository {
+
+    private let api: NovelListAPIDataStore
+
+    init(api: NovelListAPIDataStore) {
+        self.api = api
+    }
+    
+    func get() -> Single<NovelListResponse> {
+        return api.get()
+    }
+}
+
+public protocol NovelListResponse{}
+
+struct NovelListResponseImpl: NovelListResponse {}
+

--- a/Domain/Translator/NovelListTranslator.swift
+++ b/Domain/Translator/NovelListTranslator.swift
@@ -17,23 +17,22 @@ enum NovelListTranslatorProvider {
 }
 
 protocol NovelListTranslator {
-    func convert(from response: Single<NovelListResponse>) -> Single<NovelListModel>
+    func convert(from response: Single<QiitaItemListResponse>) -> Single<NovelListModel>
 }
 
 private struct NovelListTranslatorImpl: NovelListTranslator {
 
-    func convert(from response: Single<NovelListResponse>) -> Single<NovelListModel> {
-        return .just(NovelListModelImpl(response))
+    func convert(from response: Single<QiitaItemListResponse>) -> Single<NovelListModel> {
+        return response.map { NovelListModel($0)}
+//        return .just(NovelListModel(response))
     }
 }
 
-protocol NovelListModel{}
+public struct NovelListModel{
 
-private struct NovelListModelImpl: NovelListModel {
+    public let text: String
     
-    let text: String
-    
-    init(_ model: Single<NovelListResponse>) {
+    init(_ model: QiitaItemListResponse) {
         self.text = "test"
     }
 }

--- a/Domain/Translator/NovelListTranslator.swift
+++ b/Domain/Translator/NovelListTranslator.swift
@@ -24,15 +24,27 @@ private struct NovelListTranslatorImpl: NovelListTranslator {
 
     func convert(from response: Single<QiitaItemListResponse>) -> Single<NovelListModel> {
         return response.map { NovelListModel($0)}
-//        return .just(NovelListModel(response))
     }
 }
 
 public struct NovelListModel{
 
-    public let text: String
+    public let items: [Item]
     
-    init(_ model: QiitaItemListResponse) {
-        self.text = "test"
+    init(_ response: QiitaItemListResponse) {
+        self.items = response.items.map {Item(item: $0)}
+    }
+    
+    public struct Item {
+
+        public let title: String
+        public let likesCount: Int
+        public let userName: String
+        
+        init(item: QiitaItemListResponse.Item) {
+            self.title = item.title
+            self.likesCount = item.likesCount
+            self.userName = item.user.id
+        }
     }
 }

--- a/Domain/Translator/NovelListTranslator.swift
+++ b/Domain/Translator/NovelListTranslator.swift
@@ -1,0 +1,39 @@
+//
+//  NovelListTranslator.swift
+//  Domain
+//
+//  Created by ichikawa on 2020/09/03.
+//
+
+import Foundation
+import DataStore
+import RxSwift
+
+enum NovelListTranslatorProvider {
+    
+    static func provide() -> NovelListTranslator {
+        return NovelListTranslatorImpl()
+    }
+}
+
+protocol NovelListTranslator {
+    func convert(from response: Single<NovelListResponse>) -> Single<NovelListModel>
+}
+
+private struct NovelListTranslatorImpl: NovelListTranslator {
+
+    func convert(from response: Single<NovelListResponse>) -> Single<NovelListModel> {
+        return .just(NovelListModelImpl(response))
+    }
+}
+
+protocol NovelListModel{}
+
+private struct NovelListModelImpl: NovelListModel {
+    
+    let text: String
+    
+    init(_ model: Single<NovelListResponse>) {
+        self.text = "test"
+    }
+}

--- a/Domain/UseCase/NovelListUseCase.swift
+++ b/Domain/UseCase/NovelListUseCase.swift
@@ -9,9 +9,9 @@ import Foundation
 import DataStore
 import RxSwift
 
-enum NovelListUseCaseProvider {
+public enum NovelListUseCaseProvider {
     
-    static func provide() -> NovelListUseCase {
+    public static func provide() -> NovelListUseCase {
         return NovelListUseCaseImpl(
             novelListRepository: NovelListRepositoryProvider.provide(),
             novelListTranslator: NovelListTranslatorProvider.provide()
@@ -19,7 +19,7 @@ enum NovelListUseCaseProvider {
     }
 }
 
-protocol NovelListUseCase {
+public protocol NovelListUseCase {
     func get() -> Single<NovelListModel>
 }
 

--- a/Domain/UseCase/NovelListUseCase.swift
+++ b/Domain/UseCase/NovelListUseCase.swift
@@ -1,0 +1,41 @@
+//
+//  NovelListUseCase.swift
+//  Domain
+//
+//  Created by ichikawa on 2020/09/01.
+//
+
+import Foundation
+import DataStore
+import RxSwift
+
+enum NovelListUseCaseProvider {
+    
+    static func provide() -> NovelListUseCase {
+        return NovelListUseCaseImpl(
+            novelListRepository: NovelListRepositoryProvider.provide(),
+            novelListTranslator: NovelListTranslatorProvider.provide()
+        )
+    }
+}
+
+protocol NovelListUseCase {
+    func get() -> Single<NovelListModel>
+}
+
+private struct NovelListUseCaseImpl: NovelListUseCase {
+
+    private let novelListRepository: NovelListRepository
+    
+    private let novelListTranslator: NovelListTranslator
+    
+    init(novelListRepository: NovelListRepository, novelListTranslator: NovelListTranslator) {
+        self.novelListRepository = novelListRepository
+        self.novelListTranslator = novelListTranslator
+    }
+    
+    func get() -> Single<NovelListModel> {
+        return self.novelListTranslator.convert(from: self.novelListRepository.get())
+    }
+}
+

--- a/Presentation/Module/NovelList/Builder/NovelListBuilder.swift
+++ b/Presentation/Module/NovelList/Builder/NovelListBuilder.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Domain
 
 public enum NovelListBuilder {
 
@@ -18,7 +19,8 @@ public enum NovelListBuilder {
 
         let viewModel = NovelListViewModel(
             extra: .init(
-                wireframe: wireframe
+                wireframe: wireframe,
+                useCase: NovelListUseCaseProvider.provide()
             )
         )
 

--- a/Presentation/Module/NovelList/ViewController/NovelListViewController.storyboard
+++ b/Presentation/Module/NovelList/ViewController/NovelListViewController.storyboard
@@ -16,9 +16,13 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="pdP-5r-5RR">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="500" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="pdP-5r-5RR">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="iav-FZ-nnu" id="sYm-hQ-w8c"/>
+                                    <outlet property="delegate" destination="iav-FZ-nnu" id="P6q-8H-OoD"/>
+                                </connections>
                             </tableView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
@@ -30,6 +34,9 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Hi6-qD-GbQ"/>
                     </view>
+                    <connections>
+                        <outlet property="tableView" destination="pdP-5r-5RR" id="46X-BC-SSe"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DtD-zc-aFp" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Presentation/Module/NovelList/ViewController/NovelListViewController.swift
+++ b/Presentation/Module/NovelList/ViewController/NovelListViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Domain
 
 final class NovelListViewController: UIViewController {
 
@@ -43,5 +44,29 @@ extension NovelListViewController {
 extension NovelListViewController {
 
     private func bindOutput() {
+        
+        self.viewModel.output.novelListModel
+            .bind { [weak self] _ in
+                self?.tableView.reloadData()
+        }
+        .disposed(by: disposeBag)
+        
+    }
+}
+
+extension NovelListViewController: UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return self.viewModel.output.novelListModel.value?.items.count ?? 0
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let items = self.viewModel.output.novelListModel.value?.items,
+            let item = items[safe: indexPath.row] else {
+                return UITableViewCell()
+        }
+        let cell: NovelListCell = tableView.dequeueReusableCell(for: indexPath)
+        cell.setData(item)
+        return cell
     }
 }

--- a/Presentation/Module/NovelList/ViewController/NovelListViewController.swift
+++ b/Presentation/Module/NovelList/ViewController/NovelListViewController.swift
@@ -35,6 +35,7 @@ extension NovelListViewController {
         self.rx.viewWillAppear
             .map { _ in }
             .bind(to: self.viewModel.input.viewWillAppear)
+            .disposed(by: self.disposeBag)
     }
 }
 

--- a/Presentation/Module/NovelList/ViewController/Parts/NovelListCell.swift
+++ b/Presentation/Module/NovelList/ViewController/Parts/NovelListCell.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Domain
 
 final class NovelListCell: UITableViewCell {
  
@@ -15,9 +16,9 @@ final class NovelListCell: UITableViewCell {
     
     @IBOutlet private weak var dateLabel: UILabel!
     
-    func setData(_ num: Int) {
-        self.novelTitleLabel.text = "title \(num)"
-        self.authorLabel.text = "author \(num)"
-        self.dateLabel.text = "date \(num)"
+    func setData(_ item: NovelListModel.Item) {
+        self.novelTitleLabel.text = item.title
+        self.authorLabel.text = item.userName
+        self.dateLabel.text = "LGTM: \(item.likesCount)"
     }
 }

--- a/Presentation/Module/NovelList/ViewController/Parts/NovelListCell.xib
+++ b/Presentation/Module/NovelList/ViewController/Parts/NovelListCell.xib
@@ -9,7 +9,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="70" id="M3T-D5-p07" customClass="NovelListCell" customModule="Presentation" customModuleProvider="target">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="M3T-D5-p07" customClass="NovelListCell" customModule="Presentation" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="414" height="70"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="M3T-D5-p07" id="nSf-fS-FAT">
@@ -22,8 +22,8 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d3q-em-gxY">
-                        <rect key="frame" x="8" y="36" width="53" height="18"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d3q-em-gxY">
+                        <rect key="frame" x="8" y="36" width="398" height="18"/>
                         <fontDescription key="fontDescription" name="HiraginoSans-W6" family="Hiragino Sans" pointSize="18"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -41,6 +41,8 @@
                     <constraint firstItem="P3S-7q-alR" firstAttribute="leading" secondItem="nSf-fS-FAT" secondAttribute="leading" constant="8" id="fmE-hK-9Cy"/>
                     <constraint firstItem="8aN-5n-pZF" firstAttribute="top" secondItem="nSf-fS-FAT" secondAttribute="top" constant="8" id="mSS-ji-w4r"/>
                     <constraint firstItem="P3S-7q-alR" firstAttribute="top" secondItem="nSf-fS-FAT" secondAttribute="top" constant="8" id="qtw-Dy-eYr"/>
+                    <constraint firstAttribute="trailing" secondItem="d3q-em-gxY" secondAttribute="trailing" constant="8" id="un1-cE-LtE"/>
+                    <constraint firstAttribute="bottom" secondItem="d3q-em-gxY" secondAttribute="bottom" constant="16" id="vGp-YV-Qke"/>
                     <constraint firstItem="d3q-em-gxY" firstAttribute="leading" secondItem="nSf-fS-FAT" secondAttribute="leading" constant="8" id="wbh-HB-FMB"/>
                 </constraints>
             </tableViewCellContentView>

--- a/Presentation/Module/NovelList/ViewModel/NovelListViewModel.swift
+++ b/Presentation/Module/NovelList/ViewModel/NovelListViewModel.swift
@@ -33,14 +33,11 @@ extension NovelListViewModel {
     }
 
     struct Output: OutputType {
-        // e.g.
-        // let reloadAll: Observable<Void>
-        // let sections: BehaviorRelay<[NovelListViewController.Section]>
+         let novelListModel: BehaviorRelay<NovelListModel?>
     }
     
     struct State: StateType {
-        // e.g.
-        // let networkState = PublishRelay<NetworkState>()
+        let novelListModel = BehaviorRelay<NovelListModel?>(value: nil)
     }
 
     struct Extra: ExtraType {
@@ -67,12 +64,11 @@ extension NovelListViewModel {
             .disposed(by: disposeBag)
         
         fetchData.elements
-            .bind(onNext: { model in
-                print(model.self)
-            })
+            .bind(to: state.novelListModel)
             .disposed(by: disposeBag)
         
         return Output(
+            novelListModel: state.novelListModel
         )
     }
 }

--- a/Presentation/Module/NovelList/ViewModel/NovelListViewModel.swift
+++ b/Presentation/Module/NovelList/ViewModel/NovelListViewModel.swift
@@ -10,6 +10,7 @@ import Action
 import RxCocoa
 import RxSwift
 import Unio
+import Domain
 
 protocol NovelListViewModelType: AnyObject {
     var input: InputWrapper<NovelListViewModel.Input> { get }
@@ -44,6 +45,7 @@ extension NovelListViewModel {
 
     struct Extra: ExtraType {
         let wireframe: NovelListWireframe
+        let useCase: NovelListUseCase
     }
 }
 
@@ -54,13 +56,19 @@ extension NovelListViewModel {
         let state = dependency.state
         var extra = dependency.extra
         
-//        let fetchAction = Action<Void, Void> {
-//
-//        }
+        let fetchData = Action<Void, NovelListModel> {
+            extra.useCase.get()
+        }
         
         input.viewWillAppear
             .bind(onNext: {
-                
+                fetchData.execute()
+            })
+            .disposed(by: disposeBag)
+        
+        fetchData.elements
+            .bind(onNext: { model in
+                print(model.self)
             })
             .disposed(by: disposeBag)
         

--- a/Presentation/Utility/Extensions/Array+.swift
+++ b/Presentation/Utility/Extensions/Array+.swift
@@ -1,0 +1,21 @@
+//
+//  Array+.swift
+//  Presentation
+//
+//  Created by ichikawa on 2020/09/08.
+//
+
+import Foundation
+
+extension Array {
+
+    /// 範囲を超えてもクラッシュしない
+    public subscript (safe index: Int) -> Element? {
+        return self.indices ~= index ? self[index] : nil
+    }
+
+    /// 範囲を超えてもクラッシュしない
+    public subscript (reverse index: Int) -> Element {
+        return self[self.count - index - 1]
+    }
+}

--- a/Presentation/Utility/HasDisposeBag.swift
+++ b/Presentation/Utility/HasDisposeBag.swift
@@ -1,0 +1,51 @@
+//
+//  HasDisposeBag.swift
+//  smart-novel-ios
+//
+//  Created by ichikawa on 2020/09/08.
+//
+
+import Foundation
+import RxSwift
+import ObjectiveC
+
+private var disposeBagContext: UInt8 = 0
+
+/// each HasDisposeBag offers a unique RxSwift DisposeBag instance
+public protocol HasDisposeBag: class {
+
+    /// a unique RxSwift DisposeBag instance
+    var disposeBag: DisposeBag { get set }
+}
+
+extension HasDisposeBag {
+
+    func synchronizedBag<T>( _ action: () -> T) -> T {
+        objc_sync_enter(self)
+        let result = action()
+        objc_sync_exit(self)
+        return result
+    }
+
+    /// a unique RxSwift DisposeBag instance
+    public var disposeBag: DisposeBag {
+        get {
+            return synchronizedBag {
+                if let disposeObject = objc_getAssociatedObject(self, &disposeBagContext) as? DisposeBag {
+                    return disposeObject
+                }
+                let disposeObject = DisposeBag()
+                objc_setAssociatedObject(self, &disposeBagContext, disposeObject, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+                return disposeObject
+            }
+        }
+
+        set {
+            synchronizedBag {
+                objc_setAssociatedObject(self, &disposeBagContext, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            }
+        }
+    }
+}
+
+extension NSObject: HasDisposeBag {}

--- a/project.yml
+++ b/project.yml
@@ -27,6 +27,7 @@ targets:
       - carthage: RxSwift
       - carthage: RxRelay
       - carthage: RxCocoa
+      - carthage: APIKit
   Presentation:
     type: framework
     platform: iOS


### PR DESCRIPTION
### 概要
API通信を行う共通部分とそれを利用して記事一覧画面を実装

### 方針・実装
>API通信を行う共通部分

→APIKitという通信処理をいい感じに書いてくれるライブラリをRxでラップする。RequestはAPIRequestableってやつを準拠することでいい感じに共通化する

> 記事一覧画面を実装

→ APIはできてないのでQiitaの記事取得APIを使って仮実装した

### テスト、動作確認
Qiitaの記事が取得できてる！

![Qiita記事一覧](https://user-images.githubusercontent.com/42941654/92591192-646dda00-f2d8-11ea-9e49-6005352c124b.gif)


### 相談
なにやろうかな